### PR TITLE
Activate while not running interactively to ensure environment variable definition

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -8,7 +8,7 @@ if [ -f /etc/bashrc ]; then
   . /etc/bashrc
 fi
 # If not running interactively, don't do anything
-[ -z "$PS1" ] && return
+# [ -z "$PS1" ] && return
 
 # don't put duplicate lines in the history. See bash(1) for more options
 export HISTCONTROL=ignoredups


### PR DESCRIPTION
This fixes a weird bug that was occurring when running jobs with graalpy.